### PR TITLE
Fix bug with doctype

### DIFF
--- a/ext/html_tokenizer_ext/tokenizer.c
+++ b/ext/html_tokenizer_ext/tokenizer.c
@@ -369,6 +369,7 @@ static int scan_open_tag(struct tokenizer_t *tk)
   else if(is_doctype(&tk->scan)) {
     tokenizer_callback(tk, TOKEN_TAG_START, 1);
     tokenizer_callback(tk, TOKEN_TAG_NAME, 8);
+    push_context(tk, TOKENIZER_TAG_NAME);
     return 1;
   }
   else if(is_cdata_start(&tk->scan)) {

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -564,6 +564,15 @@ class HtmlTokenizer::ParserTest < Minitest::Test
     assert_equal 0, @parser.errors_count, "Expected no errors: #{@parser.errors}"
   end
 
+  def test_doctype_without_space
+    parse('<!DOCTYPE')
+    assert_equal "!DOCTYPE", @parser.tag_name
+    parse('foo')
+    assert_equal "!DOCTYPEfoo", @parser.tag_name
+
+    assert_equal 0, @parser.errors_count, "Expected no errors: #{@parser.errors}"
+  end
+
   private
 
   def parse(*parts, &block)


### PR DESCRIPTION
There can be more tag_name parts coming after `<!DOCTYPE`, so the tokenizer context should go to `TOKENIZER_TAG_NAME` to process those and exit when a whitespace is encountered.

@clayton-shopify