### PR TITLE
Free members of struct tokenizer_t when parser is freed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     minitest (5.9.0)
-    rake (11.1.2)
+    rake (12.3.0)
     rake-compiler (0.9.9)
       rake
 

--- a/ext/html_tokenizer_ext/parser.c
+++ b/ext/html_tokenizer_ext/parser.c
@@ -14,6 +14,7 @@ static void parser_free(void *ptr)
   size_t i;
 
   if(parser) {
+    tokenizer_free_members(&parser->tk);
     if(parser->doc.data) {
       DBG_PRINT("parser=%p xfree(parser->doc.data) %p", parser, parser->doc.data);
       xfree(parser->doc.data);
@@ -549,6 +550,8 @@ static VALUE parser_append_data(VALUE self, VALUE source, int is_placeholder)
     parser->tk.scan.mb_cursor = mb_cursor;
 
     tokenizer_scan_all(&parser->tk);
+
+    parser->tk.scan.string = NULL;
   }
 
   return Qtrue;

--- a/ext/html_tokenizer_ext/tokenizer.c
+++ b/ext/html_tokenizer_ext/tokenizer.c
@@ -12,16 +12,7 @@ static void tokenizer_free(void *ptr)
 {
   struct tokenizer_t *tk = ptr;
   if(tk) {
-    if(tk->current_tag) {
-      DBG_PRINT("tk=%p xfree(tk->current_tag) %p", tk, tk->current_tag);
-      xfree(tk->current_tag);
-      tk->current_tag = NULL;
-    }
-    if(tk->scan.string) {
-      DBG_PRINT("tk=%p xfree(tk->scan.string) %p", tk, tk->scan.string);
-      xfree(tk->scan.string);
-      tk->scan.string = NULL;
-    }
+    tokenizer_free_members(tk);
     DBG_PRINT("tk=%p xfree(tk)", tk);
     xfree(tk);
   }
@@ -72,6 +63,21 @@ void tokenizer_init(struct tokenizer_t *tk)
   tk->callback_data = NULL;
   tk->f_callback = NULL;
 
+  return;
+}
+
+void tokenizer_free_members(struct tokenizer_t *tk)
+{
+  if(tk->current_tag) {
+    DBG_PRINT("tk=%p xfree(tk->current_tag) %p", tk, tk->current_tag);
+    xfree(tk->current_tag);
+    tk->current_tag = NULL;
+  }
+  if(tk->scan.string) {
+    DBG_PRINT("tk=%p xfree(tk->scan.string) %p", tk, tk->scan.string);
+    xfree(tk->scan.string);
+    tk->scan.string = NULL;
+  }
   return;
 }
 

--- a/ext/html_tokenizer_ext/tokenizer.h
+++ b/ext/html_tokenizer_ext/tokenizer.h
@@ -70,6 +70,7 @@ struct tokenizer_t
 
 void Init_html_tokenizer_tokenizer(VALUE mHtmlTokenizer);
 void tokenizer_init(struct tokenizer_t *tk);
+void tokenizer_free_members(struct tokenizer_t *tk);
 void tokenizer_scan_all(struct tokenizer_t *tk);
 VALUE token_type_to_symbol(enum token_type type);
 


### PR DESCRIPTION
Fix a memory leak with members of `struct tokenizer_t` not being freed when `parser_t` is freed.