### PR TITLE
fix double free issue

### DIFF
--- a/ext/html_tokenizer_ext/extconf.rb
+++ b/ext/html_tokenizer_ext/extconf.rb
@@ -2,5 +2,11 @@ require 'mkmf'
 
 $CXXFLAGS += " -std=c++11 "
 $CXXFLAGS += " -g -Og -ggdb "
+$CFLAGS += " -g -Og -ggdb "
+
+if ENV['DEBUG']
+  $CXXFLAGS += "  -DDEBUG "
+  $CFLAGS += "  -DDEBUG "
+end
 
 create_makefile('html_tokenizer_ext')

--- a/ext/html_tokenizer_ext/parser.c
+++ b/ext/html_tokenizer_ext/parser.c
@@ -508,15 +508,6 @@ static int parser_document_append(struct parser_t *parser, const char *string, u
   return 1;
 }
 
-static inline void parser_free_scan_string(struct parser_t *parser)
-{
-  if(parser->tk.scan.string) {
-    xfree(parser->tk.scan.string);
-    parser->tk.scan.string = NULL;
-  }
-  return;
-}
-
 static VALUE parser_append_data(VALUE self, VALUE source, int is_placeholder)
 {
   struct parser_t *parser = NULL;
@@ -552,16 +543,13 @@ static VALUE parser_append_data(VALUE self, VALUE source, int is_placeholder)
     parser_adjust_line_number(parser, cursor, length);
   }
   else {
-    parser_free_scan_string(parser);
     parser->tk.scan.cursor = cursor;
-    parser->tk.scan.string = strdup(parser->doc.data);
-    parser->tk.scan.length = parser->doc.length;
+    tokenizer_set_scan_string(&parser->tk, parser->doc.data, parser->doc.length);
     parser->tk.scan.enc_index = parser->doc.enc_index;
     parser->tk.scan.mb_cursor = mb_cursor;
 
     tokenizer_scan_all(&parser->tk);
-
-    parser_free_scan_string(parser);
+    tokenizer_free_scan_string(&parser->tk);
   }
 
   return Qtrue;

--- a/ext/html_tokenizer_ext/parser.c
+++ b/ext/html_tokenizer_ext/parser.c
@@ -508,6 +508,15 @@ static int parser_document_append(struct parser_t *parser, const char *string, u
   return 1;
 }
 
+static inline void parser_free_scan_string(struct parser_t *parser)
+{
+  if(parser->tk.scan.string) {
+    xfree(parser->tk.scan.string);
+    parser->tk.scan.string = NULL;
+  }
+  return;
+}
+
 static VALUE parser_append_data(VALUE self, VALUE source, int is_placeholder)
 {
   struct parser_t *parser = NULL;
@@ -543,6 +552,7 @@ static VALUE parser_append_data(VALUE self, VALUE source, int is_placeholder)
     parser_adjust_line_number(parser, cursor, length);
   }
   else {
+    parser_free_scan_string(parser);
     parser->tk.scan.cursor = cursor;
     parser->tk.scan.string = strdup(parser->doc.data);
     parser->tk.scan.length = parser->doc.length;
@@ -551,10 +561,7 @@ static VALUE parser_append_data(VALUE self, VALUE source, int is_placeholder)
 
     tokenizer_scan_all(&parser->tk);
 
-    if(parser->tk.scan.string) {
-      xfree(parser->tk.scan.string);
-      parser->tk.scan.string = NULL;
-    }
+    parser_free_scan_string(parser);
   }
 
   return Qtrue;

--- a/ext/html_tokenizer_ext/parser.c
+++ b/ext/html_tokenizer_ext/parser.c
@@ -544,14 +544,17 @@ static VALUE parser_append_data(VALUE self, VALUE source, int is_placeholder)
   }
   else {
     parser->tk.scan.cursor = cursor;
-    parser->tk.scan.string = parser->doc.data;
+    parser->tk.scan.string = strdup(parser->doc.data);
     parser->tk.scan.length = parser->doc.length;
     parser->tk.scan.enc_index = parser->doc.enc_index;
     parser->tk.scan.mb_cursor = mb_cursor;
 
     tokenizer_scan_all(&parser->tk);
 
-    parser->tk.scan.string = NULL;
+    if(parser->tk.scan.string) {
+      xfree(parser->tk.scan.string);
+      parser->tk.scan.string = NULL;
+    }
   }
 
   return Qtrue;

--- a/ext/html_tokenizer_ext/tokenizer.c
+++ b/ext/html_tokenizer_ext/tokenizer.c
@@ -668,8 +668,10 @@ void tokenizer_set_scan_string(struct tokenizer_t *tk, const char *string, long 
   REALLOC_N(tk->scan.string, char, string ? length + 1 : 0);
   DBG_PRINT("tk=%p realloc(tk->scan.string) %p -> %p length=%lu", tk, old,
     tk->scan.string, length + 1);
-  if(string && length > 0)
+  if(string && length > 0) {
     strncpy(tk->scan.string, string, length);
+    tk->scan.string[length] = 0;
+  }
   tk->scan.length = length;
   return;
 }

--- a/ext/html_tokenizer_ext/tokenizer.h
+++ b/ext/html_tokenizer_ext/tokenizer.h
@@ -71,6 +71,8 @@ struct tokenizer_t
 void Init_html_tokenizer_tokenizer(VALUE mHtmlTokenizer);
 void tokenizer_init(struct tokenizer_t *tk);
 void tokenizer_free_members(struct tokenizer_t *tk);
+void tokenizer_set_scan_string(struct tokenizer_t *tk, const char *string, long unsigned int length);
+void tokenizer_free_scan_string(struct tokenizer_t *tk);
 void tokenizer_scan_all(struct tokenizer_t *tk);
 VALUE token_type_to_symbol(enum token_type type);
 


### PR DESCRIPTION
I thought this would take care of the issue but I was wrong: https://github.com/EiNSTeiN-/html_tokenizer/pull/3/files#r152404311

I'm not completely sure why, but `tokenizer_scan_all` sometimes doesn't return the control flow to where `parser->tk.scan.string` can be zeroed out, so `parser->tk.scan.string` keeps a copy of the pointer to `parser->doc.data`. When `parser_free` is called, both are free'd. I opted for `strdup`'ing the pointer so the tokenizer and the parser can each own a copy, this should avoid problems.

@clayton-shopify