### PR TITLE
Don't pass the -Og flag, which doesn't exist in older Clang (El Capitan)

### DIFF
--- a/ext/html_tokenizer_ext/extconf.rb
+++ b/ext/html_tokenizer_ext/extconf.rb
@@ -1,8 +1,8 @@
 require 'mkmf'
 
 $CXXFLAGS += " -std=c++11 "
-$CXXFLAGS += " -g -Og -ggdb "
-$CFLAGS += " -g -Og -ggdb "
+$CXXFLAGS += " -g -O1 -ggdb "
+$CFLAGS += " -g -O1 -ggdb "
 
 if ENV['DEBUG']
   $CXXFLAGS += "  -DDEBUG "


### PR DESCRIPTION
On OS X El Capitan, the -Og flag doesn't exist in Clang and results in an compilation error:

> compiling ../../../../ext/html_tokenizer_ext/html_tokenizer.c
> error: invalid integral value 'g' in '-Og'
> make: *** [html_tokenizer.o] Error 1
