### PR TITLE
Remove unused function parameter.

### DIFF
--- a/ext/html_tokenizer_ext/parser.c
+++ b/ext/html_tokenizer_ext/parser.c
@@ -734,7 +734,7 @@ static VALUE create_parser_error(struct parser_document_error_t *error)
   return rb_class_new_instance(4, args, klass);
 }
 
-static VALUE parser_errors_method(VALUE self, VALUE error_p)
+static VALUE parser_errors_method(VALUE self)
 {
   struct parser_t *parser = NULL;
   VALUE list;


### PR DESCRIPTION
The `rb_define_method` call already declared the arity as `0`. Removing the parameter allows the declared arity to match the function's actual arity.

Notably, this change fixes compatibility with TruffleRuby. TruffleRuby's approach to running native extensions is sensitive to these sorts of mismatches as they often indicate an unintentional error that could have security implications.