### PR TITLE
Fix compatibility with latest clang versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.9.0)
-    rake (12.3.0)
-    rake-compiler (0.9.9)
+    minitest (5.22.3)
+    rake (13.1.0)
+    rake-compiler (1.2.7)
       rake
 
 PLATFORMS
+  arm64-darwin-23
   ruby
 
 DEPENDENCIES
@@ -21,4 +22,4 @@ DEPENDENCIES
   rake-compiler
 
 BUNDLED WITH
-   1.16.1
+   2.5.6

--- a/ext/html_tokenizer_ext/parser.c
+++ b/ext/html_tokenizer_ext/parser.c
@@ -734,7 +734,7 @@ static VALUE create_parser_error(struct parser_document_error_t *error)
   return rb_class_new_instance(4, args, klass);
 }
 
-static VALUE parser_errors_method(VALUE self, VALUE error_p)
+static VALUE parser_errors_method(VALUE self)
 {
   struct parser_t *parser = NULL;
   VALUE list;

--- a/ext/html_tokenizer_ext/tokenizer.c
+++ b/ext/html_tokenizer_ext/tokenizer.c
@@ -135,7 +135,7 @@ static void tokenizer_yield_tag(struct tokenizer_t *tk, enum token_type type, lo
 {
   long unsigned int mb_length = tokenizer_mblength(tk, length);
   tk->last_token = type;
-  rb_yield_values(3, token_type_to_symbol(type), INT2NUM(tk->scan.mb_cursor), INT2NUM(tk->scan.mb_cursor + mb_length));
+  rb_yield_values(3, token_type_to_symbol(type), ULL2NUM(tk->scan.mb_cursor), ULL2NUM(tk->scan.mb_cursor + mb_length));
 }
 
 static void tokenizer_callback(struct tokenizer_t *tk, enum token_type type, long unsigned int length)
@@ -464,11 +464,9 @@ static int scan_tag_name(struct tokenizer_t *tk)
 {
   unsigned long int length = 0, tag_name_length = 0;
   const char *tag_name = NULL;
-  void *old;
 
   if(is_tag_name(&tk->scan, &tag_name, &tag_name_length)) {
     length = (tk->current_tag ? strlen(tk->current_tag) : 0);
-    old = tk->current_tag;
     REALLOC_N(tk->current_tag, char, length + tag_name_length + 1);
     DBG_PRINT("tk=%p realloc(tk->current_tag) %p -> %p length=%lu", tk, old,
       tk->current_tag,  length + tag_name_length + 1);
@@ -664,7 +662,6 @@ void tokenizer_scan_all(struct tokenizer_t *tk)
 
 void tokenizer_set_scan_string(struct tokenizer_t *tk, const char *string, long unsigned int length)
 {
-  const char *old = tk->scan.string;
   REALLOC_N(tk->scan.string, char, string ? length + 1 : 0);
   DBG_PRINT("tk=%p realloc(tk->scan.string) %p -> %p length=%lu", tk, old,
     tk->scan.string, length + 1);

--- a/html_tokenizer.gemspec
+++ b/html_tokenizer.gemspec
@@ -12,8 +12,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib", "ext"]
-
-  spec.add_development_dependency 'rake', '~> 0'
-  spec.add_development_dependency 'rake-compiler', '~> 0'
-  spec.add_development_dependency 'minitest', '~> 0'
 end


### PR DESCRIPTION
The latest clang version is now more strict and started breaking this gem:

```
parser.c:792:3: error: incompatible function pointer types passing 'VALUE (VALUE, VALUE)' (aka 'unsigned long (unsigned long, unsigned long)') to parameter of type 'VALUE (*)(VALUE)' (aka 'unsigned long
(*)(unsigned long)') [-Wincompatible-function-pointer-types]
  rb_define_method(cParser, "errors", parser_errors_method, 0);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/rubies/3.4-dev-03-19/include/ruby-3.4.0+0/ruby/internal/anyargs.h:288:135: note: expanded from macro 'rb_define_method'
                                                                                                                                      ^~~~~~
/opt/rubies/3.4-dev-03-19/include/ruby-3.4.0+0/ruby/internal/anyargs.h:277:1: note: passing argument to parameter here
RBIMPL_ANYARGS_DECL(rb_define_method, VALUE, const char *)
^
/opt/rubies/3.4-dev-03-19/include/ruby-3.4.0+0/ruby/internal/anyargs.h:255:72: note: expanded from macro 'RBIMPL_ANYARGS_DECL'
RBIMPL_ANYARGS_ATTRSET(sym) static void sym ## _00(__VA_ARGS__, VALUE(*)(VALUE), int); \
```